### PR TITLE
Feature/find all reciprocal

### DIFF
--- a/src/main/java/net/smartcosmos/dao/relationships/RelationshipDao.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/RelationshipDao.java
@@ -121,6 +121,22 @@ public interface RelationshipDao {
         String referenceUrn);
 
     /**
+     * Finds all relationships for a given reference entity in the realm of a given account and includes a
+     * {@code reciprocal} flag in the response if {@code checkReciprocal} is set to {@code true}.
+     *
+     * @param accountUrn the account URN
+     * @param entityReferenceType the entity reference type
+     * @param referenceUrn the reference entity's system-assigned URN
+     * @param checkReciprocal if set to {@code true}, a {@code reciprocal} flag will be set to indicate whether the relationship is reflexive
+     * @return a list of matching {@link RelationshipResponse} instances for the retrieved relationships
+     */
+    List<RelationshipResponse> findAll(
+        String accountUrn,
+        String entityReferenceType,
+        String referenceUrn,
+        Boolean checkReciprocal);
+
+    /**
      * Finds all reflexive relationships for a given entity in the realm of a given account.
      * <p></p>
      * A matching set of relationship contains two bidirectional relationships of the same type between reference

--- a/src/main/java/net/smartcosmos/dto/relationships/RelationshipResponse.java
+++ b/src/main/java/net/smartcosmos/dto/relationships/RelationshipResponse.java
@@ -30,10 +30,11 @@ public class RelationshipResponse {
     private final String accountUrn;
     private final Long lastModifiedTimestamp;
     private final String moniker;
+    private final Boolean reciprocal;
 
     @Builder
-    @ConstructorProperties({"urn", "entityReferenceType", "referenceUrn", "type", "relatedEntityReferenceType", "relatedReferenceUrn", "accountUrn", "lastModifiedTimestamp", "moniker"})
-    public RelationshipResponse(String urn, String entityReferenceType, String referenceUrn, String type, String relatedEntityReferenceType, String relatedReferenceUrn, String accountUrn, Long lastModifiedTimestamp, String moniker) {
+    @ConstructorProperties({"urn", "entityReferenceType", "referenceUrn", "type", "relatedEntityReferenceType", "relatedReferenceUrn", "accountUrn", "lastModifiedTimestamp", "moniker", "reciprocal"})
+    public RelationshipResponse(String urn, String entityReferenceType, String referenceUrn, String type, String relatedEntityReferenceType, String relatedReferenceUrn, String accountUrn, Long lastModifiedTimestamp, String moniker, Boolean reciprocal) {
         this.urn = urn;
         this.entityReferenceType = entityReferenceType;
         this.referenceUrn = referenceUrn;
@@ -43,6 +44,7 @@ public class RelationshipResponse {
         this.accountUrn = accountUrn;
         this.lastModifiedTimestamp = lastModifiedTimestamp;
         this.moniker = moniker;
+        this.reciprocal = reciprocal;
 
         this.version = VERSION;
     }

--- a/src/main/java/net/smartcosmos/dto/relationships/RelationshipResponse.java
+++ b/src/main/java/net/smartcosmos/dto/relationships/RelationshipResponse.java
@@ -30,7 +30,7 @@ public class RelationshipResponse {
     private final String accountUrn;
     private final Long lastModifiedTimestamp;
     private final String moniker;
-    private final Boolean reciprocal;
+    private Boolean reciprocal;
 
     @Builder
     @ConstructorProperties({"urn", "entityReferenceType", "referenceUrn", "type", "relatedEntityReferenceType", "relatedReferenceUrn", "accountUrn", "lastModifiedTimestamp", "moniker", "reciprocal"})

--- a/src/test/java/net/smartcosmos/dto/relationships/RelationshipResponseTest.java
+++ b/src/test/java/net/smartcosmos/dto/relationships/RelationshipResponseTest.java
@@ -56,4 +56,50 @@ public class RelationshipResponseTest {
 
         assertFalse(jsonObject.has("version"));
     }
+
+    @Test
+    public void thatObjectMapperDoesNotIncludeReciprocalIfNotSet() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        RelationshipResponse relationshipResponse = RelationshipResponse.builder()
+            .accountUrn("accountUrn")
+            .entityReferenceType("entityReferenceType")
+            .referenceUrn("referenceUrn")
+            .relatedEntityReferenceType("relatedEntityReferenceType")
+            .relatedReferenceUrn("relatedReferenceUrn")
+            .lastModifiedTimestamp(123L)
+            .type("type")
+            .urn("urn")
+            .moniker("moniker")
+            .build();
+
+        String jsonString = mapper.writeValueAsString(relationshipResponse);
+        JSONObject jsonObject = new JSONObject(jsonString);
+
+        assertFalse(jsonObject.has("reciprocal"));
+    }
+
+    @Test
+    public void thatObjectMapperIncludeReciprocalIfSet() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        RelationshipResponse relationshipResponse = RelationshipResponse.builder()
+            .accountUrn("accountUrn")
+            .entityReferenceType("entityReferenceType")
+            .referenceUrn("referenceUrn")
+            .relatedEntityReferenceType("relatedEntityReferenceType")
+            .relatedReferenceUrn("relatedReferenceUrn")
+            .lastModifiedTimestamp(123L)
+            .type("type")
+            .urn("urn")
+            .moniker("moniker")
+            .build();
+
+        relationshipResponse.setReciprocal(true);
+
+        String jsonString = mapper.writeValueAsString(relationshipResponse);
+        JSONObject jsonObject = new JSONObject(jsonString);
+
+        assertTrue(jsonObject.has("reciprocal"));
+    }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

A `reciprocal` field is added to `RelationshipResponse` which is required to support the `checkReciprocal` flag in the _Look up all relationships_ request.

However, this field usually isn't included in the `RelationshipResponse` entities. It defaults to `null` and therefore doesn't show up in the serialized JSON body.

In addition, another `findAll()` method is added that includes the `checkReciprocal` flag after I misunderstood the intended output previously.
### How is this patch documented?

Code or v2 API documentation.
### How was this patch tested?

Unit tests.
#### Depends On

`findAllReflexive` in the JPA implementation will require this change.
